### PR TITLE
Fixed bug in indexer setter

### DIFF
--- a/Assets/HTC.UnityPlugin/Utility/Container/IndexedSet.cs
+++ b/Assets/HTC.UnityPlugin/Utility/Container/IndexedSet.cs
@@ -70,7 +70,7 @@ namespace HTC.UnityPlugin.Utility
                 T item = m_List[index];
                 m_Dictionary.Remove(item);
                 m_List[index] = value;
-                m_Dictionary.Add(item, index);
+                m_Dictionary.Add(value, index);
             }
         }
 


### PR DESCRIPTION
Fixed a bug in the indexer setter that prevented the Dictionary from updating correctly (while the List did update correctly). The dictionary was re-assigning the old value again, instead of assigning the new one.

So this would fail:
```
	indexedSetInstance[0] = 666;
	Assert(indexedSetInstance.Contains(666));
```

Fortunately I didn't run into it during runtime. Just noticed it while I was looking at the code. :) Good job btw; the code so far feels much cleaner than what I saw in the SteamVR plugin. 👍 