### PR TITLE
Cache reset poses so effectTargets maintain position

### DIFF
--- a/Assets/HTC.UnityPlugin/ViveInputUtility/Examples/5.ColliderEvent/Scripts/ResetButton.cs
+++ b/Assets/HTC.UnityPlugin/ViveInputUtility/Examples/5.ColliderEvent/Scripts/ResetButton.cs
@@ -38,12 +38,19 @@ public class ResetButton : MonoBehaviour
 
     private void Start()
     {
+        CacheResetPoses();
+    }
+
+    // Updates the resetPoses with the current effectTarget poses
+    private void CacheResetPoses()
+    {
         resetPoses = new RigidPose[effectTargets.Length];
         for (int i = 0; i < effectTargets.Length; ++i)
         {
             resetPoses[i] = new RigidPose(effectTargets[i]);
         }
     }
+
 #if UNITY_EDITOR
     protected virtual void OnValidate()
     {
@@ -77,6 +84,7 @@ public class ResetButton : MonoBehaviour
     {
         if (eventData.button == m_activeButton && pressingEvents.Add(eventData) && pressingEvents.Count == 1)
         {
+            CacheResetPoses();
             buttonObject.localPosition += buttonDownDisplacement;
         }
     }


### PR DESCRIPTION
If the effectTargets are moved after the application is running when OnColliderEventPressUp restores the positions from resetPoses back into the effectTargets they'll get restored back to their original position in the scene instead of their updated positions. Called CacheResetPoses() from OnColliderEventPressEnter to update the cache so the restore works properly.

This is an additional fix to issue #114.