### PR TITLE
add null checks BasicGrabbable, allow different renderers for reticle…

### DIFF
--- a/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/BasicGrabbable.cs
+++ b/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/BasicGrabbable.cs
@@ -39,6 +39,12 @@ namespace HTC.UnityPlugin.Vive
 
             public static void Release(Grabber grabber)
             {
+                ViveColliderEventCaster caster = grabber.eventData.eventCaster as ViveColliderEventCaster;
+                if (caster != null && !caster.canGrab) {
+                    caster.canGrab = true;
+                    return; 
+                }
+
                 grabber.eventData = null;
                 m_pool.Release(grabber);
             }
@@ -205,8 +211,10 @@ namespace HTC.UnityPlugin.Vive
             if (!IsValidGrabButton(eventData)) { return; }
             if(singleItemGrab) {
             	ViveColliderEventCaster caster = eventData.eventCaster as ViveColliderEventCaster;
-            	if (!caster.canGrab) { return; }
-        	}
+            	if (caster!=null&&!caster.canGrab) {
+                    return; 
+                }
+            } 
             if (!m_allowMultipleGrabbers)
             {
                 ClearGrabbers(false);
@@ -276,11 +284,9 @@ namespace HTC.UnityPlugin.Vive
                 ForceRelease();
             }
             if(singleItemGrab) {
-            	if (!IsValidGrabButton(eventData)) { return; }
             	ViveColliderEventCaster caster = eventData.eventCaster as ViveColliderEventCaster;
             	if (isGrabbed)
             	{
-                	caster.canGrab = true;
                     if (m_onDrop != null)
                     {
                         m_onDrop.Invoke(this);

--- a/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/ReticlePoser.cs
+++ b/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/ReticlePoser.cs
@@ -20,7 +20,7 @@ public class ReticlePoser : MonoBehaviour
     public GameObject hitTarget;
     public float hitDistance;
     public Material defaultReticleMaterial;
-    public MeshRenderer[] reticleRenderer;
+    public Renderer[] reticleRenderer;
 
     public bool autoScaleReticle = false;
     public int sizeInPixels = 50;
@@ -34,9 +34,10 @@ public class ReticlePoser : MonoBehaviour
             raycaster = tr.GetComponentInChildren<Pointer3DRaycaster>(true);
         }
 
-        reticleRenderer = GetComponentsInChildren<MeshRenderer>(true);
+        reticleRenderer = GetComponentsInChildren<Renderer>(true);
     }
 #endif
+    public Renderer rendererToDisable;
     protected virtual void LateUpdate()
     {
         var points = raycaster.BreakPoints;
@@ -47,13 +48,21 @@ public class ReticlePoser : MonoBehaviour
         {
             reticleForDefaultRay.gameObject.SetActive(false);
             reticleForCurvedRay.gameObject.SetActive(false);
+            if(rendererToDisable!=null)
+            {
+                rendererToDisable.enabled = false;
+            }
             return;
         }
 
         var isCurvedRay = raycaster.CurrentSegmentGenerator() != null;
 
         if (reticleForDefaultRay != null) { reticleForDefaultRay.gameObject.SetActive(!isCurvedRay); }
-        if (reticleForCurvedRay != null) { reticleForCurvedRay.gameObject.SetActive(isCurvedRay); }
+        if (reticleForCurvedRay != null) { 
+            reticleForCurvedRay.gameObject.SetActive(isCurvedRay);
+            if(rendererToDisable!=null)
+                rendererToDisable.enabled = isCurvedRay;
+        }
 
         var targetReticle = isCurvedRay ? reticleForCurvedRay : reticleForDefaultRay;
         if (result.isValid)
@@ -111,7 +120,7 @@ public class ReticlePoser : MonoBehaviour
     {
         if (reticleRenderer == null || reticleRenderer.Length == 0) { return; }
 
-        foreach (MeshRenderer mr in reticleRenderer)
+        foreach (Renderer mr in reticleRenderer)
         {
             mr.material = mat;
         }


### PR DESCRIPTION
…poser

- add null checks and remove duplicate code for singleItemGrab option in BasicGrabbable
- allow different renderers (e.g. sprite renderer) for ReticlePoser for teleporting