### PR TITLE
Fix for Oculus Quest Controllers

### DIFF
--- a/Assets/HTC.UnityPlugin/VRModule/Modules/OculusVRModule.cs
+++ b/Assets/HTC.UnityPlugin/VRModule/Modules/OculusVRModule.cs
@@ -163,6 +163,7 @@ namespace HTC.UnityPlugin.VRModuleManagement
 #endif
 
 #if VIU_OCULUSVR_1_32_0_OR_NEWER || VIU_OCULUSVR_1_36_0_OR_NEWER || VIU_OCULUSVR_1_37_0_OR_NEWER
+#if VIU_OCULUSVR_AVATAR
         private class RenderModelCreator : RenderModelHook.RenderModelCreator
         {
             private uint m_index = INVALID_DEVICE_INDEX;
@@ -250,7 +251,7 @@ namespace HTC.UnityPlugin.VRModuleManagement
                 return m_index == s_leftHandIndex || m_index == s_rightHandIndex;
             }
         }
-
+#endif
         private static OculusVRModule s_moduleInstance;
 #endif
 


### PR DESCRIPTION
Model previously didn't show up if build target was standalone or Oculus Avatars asmdef wasn't part of the project. Now, RenderModelCreator in OculusVRModule.cs falls back to the default instead of using VIUOculusVRRenderModel.cs, which only seems to provide avatar functionality. Fix for #219 