### PR TITLE
Fix shader override in RenderModelHook

### DIFF
--- a/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/RenderModelHook.cs
+++ b/Assets/HTC.UnityPlugin/ViveInputUtility/Scripts/Misc/RenderModelHook.cs
@@ -130,6 +130,14 @@ namespace HTC.UnityPlugin.Vive
                         shouldActiveModelObj = Instantiate(shouldActiveModelPrefab);
                         shouldActiveModelObj.transform.position = Vector3.zero;
                         shouldActiveModelObj.transform.rotation = Quaternion.identity;
+                        if (hook.m_overrideShader != null)
+                        {
+                            var renderer = shouldActiveModelObj.GetComponentInChildren<Renderer>();
+                            if (renderer != null)
+                            {
+                                renderer.material.shader = hook.m_overrideShader;
+                            }
+                        }
                         shouldActiveModelObj.transform.SetParent(hook.transform, false);
                         m_modelObjs[shouldActiveModelNum] = shouldActiveModelObj;
                         m_activeModel = shouldActiveModelNum;


### PR DESCRIPTION
Fix for #227 and #221 - I basically just grabbed the code from the old RenderModelHook and added it back in, looks like it was removed in 567fbb245904f8bbee724189391e28d9ca2f7dfe and since then the inspector field for the shader override hasn't done anything